### PR TITLE
Update public routes to /voting and /resources, add portal redirect and aliases

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -95,6 +95,37 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requiredRole 
   return children;
 };
 
+const PortalRedirect: React.FC = () => {
+  const { userProfile, loading, error } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto mb-4"></div>
+          <p className="text-gray-600 font-bold">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <Navigate to={ROUTES.PUBLIC.LOGIN} replace />;
+  }
+
+  if (!userProfile) {
+    return <Navigate to={ROUTES.PUBLIC.LOGIN} replace />;
+  }
+
+  const userRoleNormalized = normalizeRole(userProfile.role);
+
+  if (userRoleNormalized === UserRole.APPLICANT) {
+    return <Navigate to={ROUTES.PORTAL.APPLICANT} replace />;
+  }
+
+  return <Navigate to={ROUTES.PORTAL.DASHBOARD} replace />;
+};
+
 // Main routes component (must be inside Router)
 const AppRoutes: React.FC = () => {
   return (
@@ -102,17 +133,36 @@ const AppRoutes: React.FC = () => {
       {/* Public Routes */}
       <Route path={ROUTES.PUBLIC.HOME} element={<LandingPage />} />
       <Route path={ROUTES.PUBLIC.VOTING_ZONE} element={<PostcodeCheckPage />} />
-      <Route path="/public-voting" element={<PublicVotingPage />} />
+      <Route path={ROUTES.PUBLIC.VOTING_LIVE} element={<PublicVotingPage />} />
+      <Route path={ROUTES.PUBLIC.ALIASES.VOTING_ZONE} element={<Navigate to={ROUTES.PUBLIC.VOTING_ZONE} replace />} />
+      <Route path={ROUTES.PUBLIC.ALIASES.VOTING_LIVE} element={<Navigate to={ROUTES.PUBLIC.VOTING_LIVE} replace />} />
       <Route path={ROUTES.PUBLIC.PRIORITIES} element={<PrioritiesPage />} />
       <Route path={ROUTES.PUBLIC.RESOURCES} element={<DocumentsPage />} />
+      <Route path={ROUTES.PUBLIC.ALIASES.RESOURCES} element={<Navigate to={ROUTES.PUBLIC.RESOURCES} replace />} />
       <Route path={ROUTES.PUBLIC.TIMELINE} element={<TimelinePage />} />
       <Route path={ROUTES.PUBLIC.LOGIN} element={<LoginPage />} />
 
       {/* Protected Routes - All authenticated users */}
       <Route
+        path={ROUTES.PORTAL.ROOT}
+        element={
+          <ProtectedRoute>
+            <PortalRedirect />
+          </ProtectedRoute>
+        }
+      />
+      <Route
         path={ROUTES.PORTAL.DASHBOARD}
         element={
           <ProtectedRoute>
+            <Dashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path={ROUTES.PORTAL.APPLICANT}
+        element={
+          <ProtectedRoute requiredRole={UserRole.APPLICANT}>
             <Dashboard />
           </ProtectedRoute>
         }

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -88,10 +88,12 @@ export const SecureLayout: React.FC<LayoutProps & { userRole: UserRole }> = ({ c
   const normalizedRole = (userRole || '').toString().toUpperCase();
   const isAdmin = normalizedRole === UserRole.ADMIN || normalizedRole === 'ADMIN';
   const isCommittee = normalizedRole === UserRole.COMMITTEE || normalizedRole === 'COMMITTEE';
+  const isApplicant = normalizedRole === UserRole.APPLICANT || normalizedRole === 'APPLICANT';
+  const dashboardRoute = isApplicant ? ROUTES.PORTAL.APPLICANT : ROUTES.PORTAL.DASHBOARD;
 
   const NavLinks = () => (
     <>
-      <Link to={ROUTES.PORTAL.DASHBOARD} onClick={() => setSidebarOpen(false)} className={`flex items-center space-x-3 px-4 py-3 rounded-lg transition text-sm font-bold ${isActive(ROUTES.PORTAL.DASHBOARD)}`}>
+      <Link to={dashboardRoute} onClick={() => setSidebarOpen(false)} className={`flex items-center space-x-3 px-4 py-3 rounded-lg transition text-sm font-bold ${isActive(dashboardRoute)}`}>
         <LayoutDashboard size={18} />
         <span>My Dashboard</span>
       </Link>

--- a/pages/public/LandingPage.tsx
+++ b/pages/public/LandingPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { PublicLayout } from '../../components/Layout';
 import { ArrowRight, MapPin, Users, Vote, FileText, CheckCircle2, Heart, Sparkles } from 'lucide-react';
 import { AREA_DATA } from '../../constants';
+import { ROUTES } from '../../utils';
 
 const LandingPage: React.FC = () => {
   const areas = Object.values(AREA_DATA);
@@ -32,7 +33,7 @@ const LandingPage: React.FC = () => {
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
               <Link
-                to="/vote"
+                to={ROUTES.PUBLIC.VOTING_ZONE}
                 className="group bg-teal-500 hover:bg-teal-400 text-purple-950 px-8 py-4 rounded-xl font-bold text-lg shadow-2xl transition-all transform hover:scale-105 flex items-center gap-2"
               >
                 <Vote size={24} />
@@ -41,7 +42,7 @@ const LandingPage: React.FC = () => {
               </Link>
 
               <Link
-                to="/priorities"
+                to={ROUTES.PUBLIC.PRIORITIES}
                 className="group bg-white/10 hover:bg-white/20 backdrop-blur-sm border-2 border-white/30 text-white px-8 py-4 rounded-xl font-bold text-lg transition-all flex items-center gap-2"
               >
                 <FileText size={24} />
@@ -118,7 +119,7 @@ const LandingPage: React.FC = () => {
               </p>
 
               <Link
-                to="/priorities"
+                to={ROUTES.PUBLIC.PRIORITIES}
                 className="inline-flex items-center gap-2 text-purple-600 hover:text-purple-800 font-bold text-sm group-hover:gap-3 transition-all"
               >
                 View {area.name} Priorities
@@ -177,13 +178,13 @@ const LandingPage: React.FC = () => {
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Link
-            to="/documents"
+            to={ROUTES.PUBLIC.RESOURCES}
             className="bg-purple-600 hover:bg-purple-700 text-white px-8 py-4 rounded-xl font-bold transition-all shadow-lg hover:shadow-xl"
           >
             Application Resources
           </Link>
           <Link
-            to="/login"
+            to={ROUTES.PUBLIC.LOGIN}
             className="bg-white hover:bg-gray-50 text-purple-600 border-2 border-purple-600 px-8 py-4 rounded-xl font-bold transition-all"
           >
             Access Secure Portal

--- a/pages/public/PostcodeCheckPage.tsx
+++ b/pages/public/PostcodeCheckPage.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { PublicLayout } from '../../components/Layout';
 import { Search, MapPin, CheckCircle2, XCircle, ArrowRight, Info, Vote, FileText } from 'lucide-react';
 import { AREA_DATA } from '../../constants';
 import { DataService } from '../../services/firebase';
 import { PortalSettings } from '../../types';
+import { ROUTES } from '../../utils';
 
 const PostcodeCheckPage: React.FC = () => {
-  const navigate = useNavigate();
   const [postcode, setPostcode] = useState('');
   const [result, setResult] = useState<{ eligible: boolean; area?: string; formUrl?: string } | null>(null);
   const [isChecking, setIsChecking] = useState(false);
@@ -169,7 +169,7 @@ const PostcodeCheckPage: React.FC = () => {
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <Link
-                    to="/login"
+                    to={ROUTES.PUBLIC.LOGIN}
                     className="inline-flex items-center justify-center gap-2 bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded-xl font-bold transition-all shadow-md hover:shadow-lg"
                   >
                     <FileText size={18} />
@@ -178,7 +178,7 @@ const PostcodeCheckPage: React.FC = () => {
 
                   {settings?.votingOpen ? (
                     <Link
-                      to="/public-voting"
+                      to={ROUTES.PUBLIC.VOTING_LIVE}
                       className="inline-flex items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-xl font-bold transition-all shadow-md hover:shadow-lg"
                     >
                       <Vote size={18} />
@@ -213,7 +213,7 @@ const PostcodeCheckPage: React.FC = () => {
                   If the pilot is successful, there may be opportunities to expand the programme to other areas in the future.
                 </p>
                 <Link
-                  to="/"
+                  to={ROUTES.PUBLIC.HOME}
                   className="inline-flex items-center gap-2 text-purple-600 hover:text-purple-800 font-bold"
                 >
                   Learn More About the Initiative

--- a/pages/public/PrioritiesPage.tsx
+++ b/pages/public/PrioritiesPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { PublicLayout } from '../../components/Layout';
 import { BarChart3, Users, TrendingUp, Info, CheckCircle2 } from 'lucide-react';
 import { PRIORITIES_DATA, AREA_DATA } from '../../constants';
+import { ROUTES } from '../../utils';
 
 const PrioritiesPage: React.FC = () => {
   const [selectedArea, setSelectedArea] = useState<'blaenavon' | 'thornhill' | 'trevethin'>('blaenavon');
@@ -190,7 +191,7 @@ const PrioritiesPage: React.FC = () => {
                 Submit Application for {currentAreaName}
               </a>
               <Link
-                to="/documents"
+                to={ROUTES.PUBLIC.RESOURCES}
                 className="bg-white/10 hover:bg-white/20 backdrop-blur-sm border-2 border-white/30 text-white px-8 py-4 rounded-xl font-bold transition-all"
               >
                 View Application Guidance

--- a/pages/public/TimelinePage.tsx
+++ b/pages/public/TimelinePage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { PublicLayout } from '../../components/Layout';
 import { Calendar, CheckCircle2, Clock, Circle, ArrowRight, Users, FileText, Vote, Trophy } from 'lucide-react';
+import { ROUTES } from '../../utils';
 
 interface Milestone {
   id: number;
@@ -309,14 +310,14 @@ const TimelinePage: React.FC = () => {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link
-              to="/priorities"
+              to={ROUTES.PUBLIC.PRIORITIES}
               className="bg-teal-500 hover:bg-teal-400 text-purple-950 px-8 py-4 rounded-xl font-bold transition-all shadow-lg hover:shadow-xl inline-flex items-center justify-center gap-2"
             >
               View Priorities
               <ArrowRight size={20} />
             </Link>
             <Link
-              to="/documents"
+              to={ROUTES.PUBLIC.RESOURCES}
               className="bg-white/10 hover:bg-white/20 backdrop-blur-sm border-2 border-white/30 text-white px-8 py-4 rounded-xl font-bold transition-all inline-flex items-center justify-center gap-2"
             >
               Application Documents

--- a/pages/secure/Dashboard.tsx
+++ b/pages/secure/Dashboard.tsx
@@ -1130,7 +1130,7 @@ const CommunityDashboard: React.FC<CommunityDashboardProps> = ({ currentUser, na
           </p>
           {votingOpen ? (
             <button
-              onClick={() => navigate('/public-voting')}
+              onClick={() => navigate(ROUTES.PUBLIC.VOTING_LIVE)}
               className="w-full bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg font-bold transition"
             >
               Vote on Projects
@@ -1193,7 +1193,7 @@ const CommunityDashboard: React.FC<CommunityDashboardProps> = ({ currentUser, na
                 View Timeline
               </button>
               <button
-                onClick={() => navigate('/documents')}
+                onClick={() => navigate(ROUTES.PUBLIC.RESOURCES)}
                 className="bg-white hover:bg-blue-50 text-blue-700 border-2 border-blue-300 px-4 py-2 rounded-lg font-bold text-sm transition"
               >
                 Resources

--- a/utils.ts
+++ b/utils.ts
@@ -27,10 +27,16 @@ export const ROUTES = {
   PUBLIC: {
     HOME: '/',
     PRIORITIES: '/priorities',
-    VOTING_ZONE: '/vote',
-    RESOURCES: '/documents',
+    VOTING_ZONE: '/voting',
+    VOTING_LIVE: '/voting/live',
+    RESOURCES: '/resources',
     TIMELINE: '/timeline',
     LOGIN: '/login',
+    ALIASES: {
+      VOTING_ZONE: '/vote',
+      VOTING_LIVE: '/public-voting',
+      RESOURCES: '/documents',
+    },
   },
   
   // Secure portal routes


### PR DESCRIPTION
### Motivation
- Standardise public routes so the voting zone and resources use `/voting` and `/resources` while preserving legacy paths for backward compatibility. 
- Provide a role-aware entry at `/portal` that redirects applicants to an applicant dashboard and committee/admin to the existing dashboard. 
- Centralise route usage so pages and navigation use the canonical `ROUTES` constants and avoid scattered hardcoded paths. 
- Prevent regressions by keeping aliases (e.g., `/vote`, `/public-voting`, `/documents`) that redirect to the new routes.

### Description
- Updated `utils.ts` to change public route constants: `VOTING_ZONE` -> `/voting`, added `VOTING_LIVE` -> `/voting/live`, `RESOURCES` -> `/resources`, and added an `ALIASES` object mapping legacy paths to the canonical routes. 
- Added a `PortalRedirect` component and registered a `ROUTES.PORTAL.ROOT` route in `App.tsx` to perform role-based redirects, plus an explicit `ROUTES.PORTAL.APPLICANT` route and alias redirect routes for legacy public paths. 
- Rewired navigation and CTAs across public pages (`pages/public/*`), secure dashboard (`pages/secure/Dashboard.tsx`), and layout (`components/Layout.tsx`) to use the `ROUTES` constants and to route applicants to the applicant entry point while keeping committee/admin behavior unchanged. 
- Minor cleanup to remove some hardcoded path strings and centralise route usage for future changes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696170d4dec88322890917c54fbda366)