### PR TITLE
Restrict committee scoring to assignments

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -96,7 +96,7 @@ export const SecureLayout: React.FC<LayoutProps & { userRole: UserRole }> = ({ c
         <span>My Dashboard</span>
       </Link>
 
-      {(isCommittee || isAdmin) && (
+      {isCommittee && (
         <Link to={ROUTES.PORTAL.SCORING} onClick={() => setSidebarOpen(false)} className={`flex items-center space-x-3 px-4 py-3 rounded-lg transition text-sm font-bold ${isActive(ROUTES.PORTAL.SCORING)}`}>
           <BarChart3 size={18} />
           <span>Matrix Evaluation</span>

--- a/pages/secure/Dashboard.tsx
+++ b/pages/secure/Dashboard.tsx
@@ -76,10 +76,7 @@ const Dashboard: React.FC = () => {
         setApplications(appsData.filter(app => app.userId === user.uid));
       } else if (user.role === 'committee') {
         const assignedAppIds = assignmentsData.map(a => a.applicationId);
-        const committeeApps = appsData.filter(app =>
-          assignedAppIds.includes(app.id) ||
-          (user.area && (app.area === user.area || app.area === 'Cross-Area'))
-        );
+        const committeeApps = appsData.filter(app => assignedAppIds.includes(app.id));
         setApplications(committeeApps);
       } else {
         setApplications(appsData);
@@ -559,10 +556,8 @@ const CommitteeDashboard: React.FC<CommitteeDashboardProps> = ({
   const stage1Apps = applications.filter(app => app.status === 'Submitted-Stage1');
   const stage2Apps = applications.filter(app => app.status === 'Submitted-Stage2' || app.status === 'Invited-Stage2');
 
-  // Committee members can only see applications in their assigned area
-  const filteredApps = currentUser.area
-    ? applications.filter(app => app.area === currentUser.area || app.area === 'Cross-Area')
-    : applications;
+  const assignedAppIds = new Set(assignments.map(assignment => assignment.applicationId));
+  const filteredApps = applications.filter(app => assignedAppIds.has(app.id));
 
   // Check if voting is allowed based on portal settings
   const isVotingAllowed = portalSettings?.votingOpen !== false;
@@ -617,13 +612,13 @@ const CommitteeDashboard: React.FC<CommitteeDashboardProps> = ({
         />
       </div>
 
-      {/* Area Indicator - Committee members can only see their assigned area */}
+      {/* Area Indicator - Context only */}
       {currentUser.area && (
         <div className="bg-white rounded-xl shadow-md p-4">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
               <Filter className="text-gray-600" size={20} />
-              <span className="font-semibold text-gray-700">Your Assigned Area:</span>
+              <span className="font-semibold text-gray-700">Your Area (context):</span>
             </div>
             <span className="px-4 py-2 rounded-lg font-semibold bg-purple-600 text-white">
               {currentUser.area}


### PR DESCRIPTION
### Motivation
- Ensure scoring is performed only by assigned committee members, preventing admins from submitting scores via the matrix.
- Enforce assignment-based filtering so committee members only see their assigned applications for Stage 2 review.
- Keep area information visible for context but do not use it as the primary filter for committee review lists.
- Prevent admins from using the Matrix Evaluation UI (admins should use AdminConsole/monitoring tools instead).

### Description
- Updated `pages/secure/ScoringMatrix.tsx` to remove admin scoring bypass, call `DataService.getAssignments(currentUser.uid)`, and filter applications to only those assigned to the current user and in Stage 2 before loading scoring data.
- Modified `pages/secure/Dashboard.tsx` to filter committee application lists by assignment ids (using `DataService.getAssignments`) and changed the area indicator copy to make the area display context-only.
- Adjusted the Committee dashboard `filteredApps` logic to derive the task list from the assignments set rather than area membership.
- Changed `components/Layout.tsx` to show the `Matrix Evaluation` nav link only for committee users (`isCommittee`) so admins no longer see it.

### Testing
- Started the dev server with `npm run dev` to validate the build and server startup, which reported Vite ready and served the app successfully.
- Attempted to run a Playwright-driven page screenshot to exercise the UI, but the browser launch crashed with a SIGSEGV and the run failed.
- No unit test suite or CI tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696170d531988322a6ff9314badcaf0d)