### PR TITLE
Add PRD canonical fields, Firestore mapping layer, and role/score normalization

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -84,10 +84,8 @@ export const SecureLayout: React.FC<LayoutProps & { userRole: UserRole }> = ({ c
 
   const isActive = (path: string) => location.pathname === path ? 'bg-purple-700 text-white shadow-inner border-l-4 border-teal-400' : 'text-purple-200 hover:bg-purple-800 hover:text-white';
 
-  // Normalize role for comparison (handles 'admin' vs 'ADMIN' case differences)
-  const normalizedRole = (userRole || '').toString().toUpperCase();
-  const isAdmin = normalizedRole === UserRole.ADMIN || normalizedRole === 'ADMIN';
-  const isCommittee = normalizedRole === UserRole.COMMITTEE || normalizedRole === 'COMMITTEE';
+  const isAdmin = userRole === UserRole.ADMIN;
+  const isCommittee = userRole === UserRole.COMMITTEE;
 
   const NavLinks = () => (
     <>

--- a/components/ScoringModal.tsx
+++ b/components/ScoringModal.tsx
@@ -42,10 +42,13 @@ export const ScoringModal: React.FC<ScoringModalProps> = ({ isOpen, onClose, app
     const newScore: Score = {
       id: `${app.id}_${user.uid}`,
       appId: app.id,
+      applicationId: app.id,
       scorerId: user.uid,
+      committeeId: user.uid,
       scorerName: user.displayName || user.username,
       weightedTotal,
       breakdown,
+      criterionScores: breakdown,
       notes,
       isFinal: true,
       createdAt: new Date().toISOString()

--- a/pages/secure/ApplicationForm.tsx
+++ b/pages/secure/ApplicationForm.tsx
@@ -5,19 +5,8 @@ import { Button, Card, Input, Badge } from '../../components/UI';
 import { api, api as AuthService } from '../../services/firebase';
 import { Application, UserRole, Area, ApplicationStatus, BudgetLine, AREAS, Round, PortalSettings } from '../../types';
 import { MARMOT_PRINCIPLES, WFG_GOALS, ORG_TYPES } from '../../constants';
-import { formatCurrency, ROUTES } from '../../utils';
+import { formatCurrency, ROUTES, toUserRole } from '../../utils';
 import { Save, Send, ArrowLeft, FileText, Upload, AlertCircle, CheckCircle } from 'lucide-react';
-
-// Helper to convert lowercase role string to UserRole enum
-const roleToUserRole = (role: string | undefined): UserRole => {
-  const normalized = (role || '').toUpperCase();
-  switch (normalized) {
-    case 'ADMIN': return UserRole.ADMIN;
-    case 'COMMITTEE': return UserRole.COMMITTEE;
-    case 'APPLICANT': return UserRole.APPLICANT;
-    default: return UserRole.PUBLIC;
-  }
-};
 
 const ApplicationForm: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -101,7 +90,7 @@ const ApplicationForm: React.FC = () => {
       }
 
       // Check permissions - applicants can only view their own applications
-      if (roleToUserRole(currentUser?.role) === UserRole.APPLICANT && app.userId !== currentUser.uid) {
+      if (toUserRole(currentUser?.role) === UserRole.APPLICANT && app.userId !== currentUser.uid) {
         setError('You do not have permission to view this application');
         setTimeout(() => navigate(ROUTES.PORTAL.APPLICATIONS), 2000);
         return;
@@ -285,7 +274,7 @@ const ApplicationForm: React.FC = () => {
 
   // Check if submission is allowed based on round settings
   const isSubmissionAllowed = (): { allowed: boolean; reason?: string } => {
-    const isAdmin = roleToUserRole(currentUser?.role) === UserRole.ADMIN;
+    const isAdmin = toUserRole(currentUser?.role) === UserRole.ADMIN;
 
     // Admin can always submit (override)
     if (isAdmin) return { allowed: true };
@@ -368,7 +357,7 @@ const ApplicationForm: React.FC = () => {
 
   // Determine if form is read-only
   const isReadOnly = () => {
-    const userRole = roleToUserRole(currentUser?.role);
+    const userRole = toUserRole(currentUser?.role);
     if (userRole === UserRole.ADMIN) return false;
     if (userRole === UserRole.COMMITTEE) return true;
     if (userRole === UserRole.APPLICANT) {
@@ -387,7 +376,7 @@ const ApplicationForm: React.FC = () => {
 
   if (loading) {
     return (
-      <SecureLayout userRole={roleToUserRole(currentUser.role)}>
+      <SecureLayout userRole={toUserRole(currentUser.role)}>
         <div className="text-center py-12">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto mb-4"></div>
           <p className="text-gray-600 font-bold">Loading application...</p>
@@ -397,7 +386,7 @@ const ApplicationForm: React.FC = () => {
   }
 
   return (
-    <SecureLayout userRole={roleToUserRole(currentUser.role)}>
+    <SecureLayout userRole={toUserRole(currentUser.role)}>
       <div className="max-w-5xl mx-auto space-y-6">
         {/* Header */}
         <div className="flex items-center gap-4">
@@ -462,7 +451,7 @@ const ApplicationForm: React.FC = () => {
         {readOnly && (
           <div className="p-4 bg-blue-50 border border-blue-200 rounded-xl">
             <p className="text-sm text-blue-800 font-medium">
-              This application is in read-only mode. {roleToUserRole(currentUser.role) === UserRole.COMMITTEE && 'Committee members can view but not edit applications.'}
+              This application is in read-only mode. {toUserRole(currentUser.role) === UserRole.COMMITTEE && 'Committee members can view but not edit applications.'}
             </p>
           </div>
         )}

--- a/pages/secure/ApplicationsList.tsx
+++ b/pages/secure/ApplicationsList.tsx
@@ -5,23 +5,12 @@ import { Button, Card, Badge, Input } from '../../components/UI';
 import { api } from '../../services/firebase';
 import { api as AuthService } from '../../services/firebase';
 import { Application, UserRole, Area, ApplicationStatus } from '../../types';
-import { formatCurrency, ROUTES } from '../../utils';
+import { formatCurrency, ROUTES, toUserRole } from '../../utils';
 import { FileText, Plus, Search, Filter, Download, Eye, Edit2, Trash2 } from 'lucide-react';
-
-// Helper to convert lowercase role string to UserRole enum
-const roleToUserRole = (role: string | undefined): UserRole => {
-  const normalized = (role || '').toUpperCase();
-  switch (normalized) {
-    case 'ADMIN': return UserRole.ADMIN;
-    case 'COMMITTEE': return UserRole.COMMITTEE;
-    case 'APPLICANT': return UserRole.APPLICANT;
-    default: return UserRole.PUBLIC;
-  }
-};
 
 // Helper to check role (case-insensitive)
 const isRole = (role: string | undefined, targetRole: UserRole): boolean => {
-  return roleToUserRole(role) === targetRole;
+  return toUserRole(role) === targetRole;
 };
 
 const ApplicationsList: React.FC = () => {
@@ -156,7 +145,7 @@ const ApplicationsList: React.FC = () => {
   }
 
   return (
-    <SecureLayout userRole={roleToUserRole(currentUser.role)}>
+    <SecureLayout userRole={toUserRole(currentUser.role)}>
       <div className="space-y-6">
         {/* Header */}
         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">

--- a/pages/secure/ScoringMatrix.tsx
+++ b/pages/secure/ScoringMatrix.tsx
@@ -6,17 +6,7 @@ import { DataService } from '../../services/firebase';
 import { Application, Score, UserRole, User, Round, PortalSettings } from '../../types';
 import { SCORING_CRITERIA } from '../../constants';
 import { BarChart3, CheckCircle, Clock, AlertCircle, Save, Eye, FileText, Lock } from 'lucide-react';
-
-// Helper to convert lowercase role string to UserRole enum
-const roleToUserRole = (role: string | undefined): UserRole => {
-  const normalized = (role || '').toUpperCase();
-  switch (normalized) {
-    case 'ADMIN': return UserRole.ADMIN;
-    case 'COMMITTEE': return UserRole.COMMITTEE;
-    case 'APPLICANT': return UserRole.APPLICANT;
-    default: return UserRole.PUBLIC;
-  }
-};
+import { isStoredRole, toUserRole } from '../../utils';
 
 interface CriterionScore {
   score: number;
@@ -43,8 +33,8 @@ const ScoringMatrix: React.FC = () => {
   const [portalSettings, setPortalSettings] = useState<PortalSettings | null>(null);
 
   // Determine role flags (safe to compute even with null user)
-  const isAdmin = currentUser?.role === UserRole.ADMIN || currentUser?.role === 'admin';
-  const isCommittee = currentUser?.role === UserRole.COMMITTEE || currentUser?.role === 'committee' || isAdmin;
+  const isAdmin = isStoredRole(currentUser?.role, 'admin');
+  const isCommittee = isStoredRole(currentUser?.role, 'committee') || isAdmin;
 
   // Check if scoring is allowed based on round/portal settings
   const isScoringAllowed = (): { allowed: boolean; reason?: string } => {
@@ -138,7 +128,7 @@ const ScoringMatrix: React.FC = () => {
 
   if (!isCommittee) {
     return (
-      <SecureLayout userRole={roleToUserRole(currentUser.role)}>
+      <SecureLayout userRole={toUserRole(currentUser.role)}>
         <div className="min-h-[60vh] flex items-center justify-center">
           <Card className="max-w-md text-center">
             <AlertCircle className="mx-auto text-red-500 mb-4" size={48} />
@@ -222,10 +212,13 @@ const ScoringMatrix: React.FC = () => {
       const score: Score = {
         id: `${selectedApp.id}_${currentUser.uid}`,
         appId: selectedApp.id,
+        applicationId: selectedApp.id,
         scorerId: currentUser.uid,
+        committeeId: currentUser.uid,
         scorerName: currentUser.displayName || currentUser.username || currentUser.email,
         weightedTotal: calculateWeightedTotal(),
         breakdown,
+        criterionScores: breakdown,
         notes,
         isFinal: true,
         createdAt: new Date().toISOString()
@@ -258,7 +251,7 @@ const ScoringMatrix: React.FC = () => {
 
   if (loading) {
     return (
-      <SecureLayout userRole={roleToUserRole(currentUser.role)}>
+      <SecureLayout userRole={toUserRole(currentUser.role)}>
         <div className="min-h-[60vh] flex items-center justify-center">
           <div className="text-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto mb-4"></div>
@@ -270,7 +263,7 @@ const ScoringMatrix: React.FC = () => {
   }
 
   return (
-    <SecureLayout userRole={roleToUserRole(currentUser.role)}>
+    <SecureLayout userRole={toUserRole(currentUser.role)}>
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="mb-8">

--- a/pages/secure/UserSettings.tsx
+++ b/pages/secure/UserSettings.tsx
@@ -4,6 +4,7 @@ import { SecureLayout } from '../../components/Layout';
 import { Card, Button, Input, Badge } from '../../components/UI';
 import { DataService, uploadProfileImage, deleteProfileImage } from '../../services/firebase';
 import { User, UserRole } from '../../types';
+import { toUserRole } from '../../utils';
 import {
   User as UserIcon,
   Camera,
@@ -17,17 +18,6 @@ import {
   AlertCircle,
   CheckCircle
 } from 'lucide-react';
-
-// Helper to convert lowercase role string to UserRole enum
-const roleToUserRole = (role: string | undefined): UserRole => {
-  const normalized = (role || '').toUpperCase();
-  switch (normalized) {
-    case 'ADMIN': return UserRole.ADMIN;
-    case 'COMMITTEE': return UserRole.COMMITTEE;
-    case 'APPLICANT': return UserRole.APPLICANT;
-    default: return UserRole.PUBLIC;
-  }
-};
 
 const UserSettings: React.FC = () => {
   const navigate = useNavigate();
@@ -187,7 +177,7 @@ const UserSettings: React.FC = () => {
     );
   }
 
-  const userRole = roleToUserRole(currentUser.role);
+  const userRole = toUserRole(currentUser.role);
 
   return (
     <SecureLayout userRole={userRole}>

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -1,6 +1,7 @@
 // services/firebase.ts
-import { User, Application, Score, PortalSettings, AdminDocument, Round, Assignment, Vote, ApplicationStatus, AuditLog } from '../types';
+import { User, Application, Score, PortalSettings, AdminDocument, Round, Assignment, Vote, ApplicationStatus, AuditLog, Area } from '../types';
 import { DEMO_USERS, DEMO_APPS, SCORING_CRITERIA } from '../constants';
+import { toStoredRole } from '../utils';
 import { initializeApp, getApp, getApps } from "firebase/app";
 import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut, updateProfile, EmailAuthProvider, reauthenticateWithCredential, updatePassword, fetchSignInMethodsForEmail } from "firebase/auth";
 import { getFirestore, doc, setDoc, getDoc, collection, getDocs, deleteDoc, writeBatch, query, where, orderBy, limit } from "firebase/firestore";
@@ -64,6 +65,141 @@ const DEFAULT_SETTINGS: PortalSettings = {
     votingOpen: false,
     scoringThreshold: 50,
     resultsReleased: false
+};
+
+const AREA_NAME_TO_ID: Record<Area, string> = {
+  'Blaenavon': 'blaenavon',
+  'Thornhill & Upper Cwmbran': 'thornhill-upper-cwmbran',
+  'Trevethin, Penygarn & St. Cadocs': 'trevethin-penygarn-st-cadocs',
+  'Cross-Area': 'cross-area'
+};
+
+const AREA_ID_TO_NAME: Record<string, Area> = Object.entries(AREA_NAME_TO_ID).reduce(
+  (acc, [name, id]) => {
+    acc[id] = name as Area;
+    return acc;
+  },
+  {} as Record<string, Area>
+);
+
+const resolveAreaId = (area?: Area | null, areaId?: string | null): string | undefined => {
+  return areaId || (area ? AREA_NAME_TO_ID[area] : undefined);
+};
+
+const resolveAreaName = (area?: Area | null, areaId?: string | null): Area | null => {
+  return area || (areaId ? AREA_ID_TO_NAME[areaId] || null : null);
+};
+
+const mapUserFromFirestore = (data: Partial<User>, docId: string): User => {
+  const normalizedRole = toStoredRole(data.role);
+  const area = resolveAreaName(data.area || null, data.areaId || null);
+  return {
+    ...data,
+    uid: data.uid || docId,
+    role: normalizedRole,
+    area,
+    areaId: resolveAreaId(area || undefined, data.areaId || undefined) || null
+  } as User;
+};
+
+const mapUserToFirestore = (user: User): Partial<User> => {
+  const normalizedRole = toStoredRole(user.role);
+  const areaId = resolveAreaId(user.area || undefined, user.areaId || undefined);
+  const area = resolveAreaName(user.area || null, areaId || null);
+  return {
+    ...user,
+    role: normalizedRole,
+    area,
+    areaId: areaId || null
+  };
+};
+
+const mapApplicationFromFirestore = (data: Partial<Application>, docId: string): Application => {
+  const applicationId = data.applicationId || data.id || docId;
+  const applicantId = data.applicantId || data.userId || '';
+  const area = resolveAreaName(data.area || null, data.areaId || null);
+  const areaId = resolveAreaId(area || undefined, data.areaId || undefined);
+  return {
+    ...data,
+    id: applicationId,
+    applicationId,
+    applicantId,
+    userId: data.userId || applicantId,
+    area: area as Area,
+    areaId
+  } as Application;
+};
+
+const mapApplicationToFirestore = (app: Application): Partial<Application> => {
+  const applicationId = app.applicationId || app.id;
+  const applicantId = app.applicantId || app.userId;
+  const areaId = resolveAreaId(app.area || undefined, app.areaId || undefined);
+  const area = resolveAreaName(app.area || null, areaId || null);
+  return {
+    ...app,
+    id: applicationId,
+    applicationId,
+    applicantId,
+    userId: app.userId || applicantId,
+    area,
+    areaId
+  };
+};
+
+const mapVoteFromFirestore = (data: Partial<Vote>, docId: string): Vote => {
+  const applicationId = data.applicationId || data.appId || '';
+  const committeeId = data.committeeId || data.voterId || '';
+  return {
+    ...data,
+    id: data.id || docId,
+    applicationId,
+    appId: data.appId || applicationId,
+    committeeId,
+    voterId: data.voterId || committeeId
+  } as Vote;
+};
+
+const mapVoteToFirestore = (vote: Vote): Partial<Vote> => {
+  const applicationId = vote.applicationId || vote.appId;
+  const committeeId = vote.committeeId || vote.voterId;
+  return {
+    ...vote,
+    applicationId,
+    appId: vote.appId || applicationId,
+    committeeId,
+    voterId: vote.voterId || committeeId
+  };
+};
+
+const mapScoreFromFirestore = (data: Partial<Score>, docId: string): Score => {
+  const applicationId = data.applicationId || data.appId || '';
+  const committeeId = data.committeeId || data.scorerId || '';
+  const criterionScores = data.criterionScores || data.breakdown || {};
+  return {
+    ...data,
+    id: data.id || docId,
+    applicationId,
+    appId: data.appId || applicationId,
+    committeeId,
+    scorerId: data.scorerId || committeeId,
+    breakdown: data.breakdown || criterionScores,
+    criterionScores
+  } as Score;
+};
+
+const mapScoreToFirestore = (score: Score): Partial<Score> => {
+  const applicationId = score.applicationId || score.appId;
+  const committeeId = score.committeeId || score.scorerId;
+  const criterionScores = score.criterionScores || score.breakdown;
+  return {
+    ...score,
+    applicationId,
+    appId: score.appId || applicationId,
+    committeeId,
+    scorerId: score.scorerId || committeeId,
+    breakdown: score.breakdown || criterionScores,
+    criterionScores
+  };
 };
 
 // --- HELPER: CSV Export ---
@@ -168,7 +304,7 @@ class AuthService {
         email,
         username: email.split('@')[0],
         displayName: name,
-        role,
+        role: toStoredRole(role),
         createdAt: Date.now()
       };
       await setDoc(doc(db, 'users', u.uid), u);
@@ -210,10 +346,12 @@ class AuthService {
         // Fetch all apps and filter in memory for complex OR logic (Area OR Cross-Area)
         // In production with large datasets, use specific queries.
         const snap = await getDocs(collection(db, "applications"));
-        const apps = snap.docs.map(d => d.data() as Application);
+        const apps = snap.docs.map(d => mapApplicationFromFirestore(d.data() as Application, d.id));
 
         if (area && area !== 'All') {
-             return apps.filter(a => a.area === area || a.area === 'Cross-Area');
+             const areaId = resolveAreaId(area as Area, null);
+             const crossAreaId = AREA_NAME_TO_ID['Cross-Area'];
+             return apps.filter(a => a.area === area || a.areaId === areaId || a.area === 'Cross-Area' || a.areaId === crossAreaId);
         }
         return apps;
       } catch (error) { return []; }
@@ -223,14 +361,30 @@ class AuthService {
       if (USE_DEMO_MODE) return this.mockCreateApp(app);
       try {
         const id = app.id || 'app_' + Date.now();
-        await setDoc(doc(db, 'applications', id), { ...app, id, updatedAt: Date.now() });
+        const mapped = mapApplicationToFirestore({ ...app, id, updatedAt: Date.now() } as Application);
+        await setDoc(doc(db, 'applications', id), mapped);
       } catch (e) { throw new Error('Failed to create application'); }
   }
 
   async updateApplication(id: string, updates: Partial<Application>): Promise<void> {
       if (USE_DEMO_MODE) return this.mockUpdateApp(id, updates);
       try {
-        await setDoc(doc(db, 'applications', id), { ...updates, updatedAt: Date.now() }, { merge: true });
+        const mappedUpdates: Partial<Application> = { ...updates, updatedAt: Date.now() };
+        if (updates.applicationId) {
+          mappedUpdates.id = updates.applicationId;
+        }
+        if (updates.applicantId || updates.userId) {
+          const applicantId = updates.applicantId || updates.userId;
+          mappedUpdates.applicantId = applicantId;
+          mappedUpdates.userId = updates.userId || applicantId;
+        }
+        if (updates.area || updates.areaId) {
+          const areaId = resolveAreaId(updates.area as Area, updates.areaId || null);
+          const areaName = resolveAreaName(updates.area || null, areaId || null);
+          mappedUpdates.areaId = areaId;
+          mappedUpdates.area = areaName || undefined;
+        }
+        await setDoc(doc(db, 'applications', id), mappedUpdates, { merge: true });
       } catch (e) { throw new Error('Failed to update application'); }
   }
 
@@ -243,25 +397,27 @@ class AuthService {
   async saveVote(vote: Vote): Promise<void> {
       if (USE_DEMO_MODE) return this.mockSaveVote(vote);
       const voteId = vote.id || `${vote.appId}_${vote.voterId}`;
-      await setDoc(doc(db, 'votes', voteId), { ...vote, id: voteId });
+      const mapped = mapVoteToFirestore({ ...vote, id: voteId } as Vote);
+      await setDoc(doc(db, 'votes', voteId), mapped);
   }
 
   async getVotes(): Promise<Vote[]> {
       if (USE_DEMO_MODE) return this.mockGetVotes();
       const snap = await getDocs(collection(db, 'votes'));
-      return snap.docs.map(d => d.data() as Vote);
+      return snap.docs.map(d => mapVoteFromFirestore(d.data() as Vote, d.id));
   }
 
   async saveScore(score: Score): Promise<void> {
       if (USE_DEMO_MODE) return this.mockSaveScore(score);
       const scoreId = score.id || `${score.appId}_${score.scorerId}`;
-      await setDoc(doc(db, 'scores', scoreId), { ...score, id: scoreId });
+      const mapped = mapScoreToFirestore({ ...score, id: scoreId } as Score);
+      await setDoc(doc(db, 'scores', scoreId), mapped);
   }
 
   async getScores(): Promise<Score[]> {
       if (USE_DEMO_MODE) return this.mockGetScores();
       const snap = await getDocs(collection(db, 'scores'));
-      return snap.docs.map(d => d.data() as Score);
+      return snap.docs.map(d => mapScoreFromFirestore(d.data() as Score, d.id));
   }
 
   // --- USERS ---
@@ -269,19 +425,12 @@ class AuthService {
       if (USE_DEMO_MODE) return this.mockGetUsers();
       const snap = await getDocs(collection(db, 'users'));
       // Ensure uid is set from document ID if missing in data
-      return snap.docs.map(d => {
-        const data = d.data() as User;
-        return { ...data, uid: data.uid || d.id };
-      });
+      return snap.docs.map(d => mapUserFromFirestore(d.data() as User, d.id));
   }
 
   async updateUser(u: User): Promise<void> {
       if (USE_DEMO_MODE) return this.mockUpdateUser(u);
-      // Normalize role to lowercase before saving
-      const normalizedUser = {
-        ...u,
-        role: u.role ? (u.role.toLowerCase() as 'admin' | 'committee' | 'applicant') : 'applicant'
-      };
+      const normalizedUser = mapUserToFirestore(u);
       await setDoc(doc(db, 'users', u.uid), normalizedUser, { merge: true });
   }
 
@@ -290,7 +439,15 @@ class AuthService {
       const ref = await this.resolveUserDocRef(uid);
       if (!ref) throw new Error("User not found");
 
-      await setDoc(ref, u, { merge: true });
+      const mappedUpdates: Partial<User> = { ...u };
+      if (u.role) mappedUpdates.role = toStoredRole(u.role);
+      if (u.area || u.areaId) {
+        const areaId = resolveAreaId(u.area as Area, u.areaId || null);
+        const areaName = resolveAreaName(u.area || null, areaId || null);
+        mappedUpdates.areaId = areaId || null;
+        mappedUpdates.area = areaName || undefined;
+      }
+      await setDoc(ref, mappedUpdates, { merge: true });
       if (auth.currentUser && auth.currentUser.uid === uid) {
           await updateProfile(auth.currentUser, { 
               displayName: u.displayName || auth.currentUser.displayName,
@@ -298,17 +455,20 @@ class AuthService {
           });
       }
       const finalSnap = await getDoc(ref);
-      return finalSnap.data() as User;
+      return mapUserFromFirestore(finalSnap.data() as User, finalSnap.id);
   }
 
   async getUserById(uid: string): Promise<User | null> {
-      if (USE_DEMO_MODE) return (DEMO_USERS as any[]).find(u => u.uid === uid) || null;
+      if (USE_DEMO_MODE) {
+        const demo = (DEMO_USERS as any[]).find(u => u.uid === uid) || null;
+        return demo ? mapUserFromFirestore(demo as User, demo.uid) : null;
+      }
       try {
           const snap = await getDoc(doc(db, 'users', uid));
-          if (snap.exists()) return snap.data() as User;
+          if (snap.exists()) return mapUserFromFirestore(snap.data() as User, snap.id);
           const q = query(collection(db, 'users'), where('uid', '==', uid));
           const qSnap = await getDocs(q);
-          return qSnap.empty ? null : qSnap.docs[0].data() as User;
+          return qSnap.empty ? null : mapUserFromFirestore(qSnap.docs[0].data() as User, qSnap.docs[0].id);
       } catch (e) { return null; }
   }
 
@@ -337,14 +497,16 @@ class AuthService {
         await signOut(secondaryAuth);
 
         // Save user profile to Firestore with matching UID
-        // Ensure role is lowercase for Firestore rules consistency
-        const normalizedRole = (u.role || 'applicant').toLowerCase() as 'admin' | 'committee' | 'applicant';
+        const normalizedRole = toStoredRole(u.role);
+        const areaId = resolveAreaId(u.area || undefined, u.areaId || undefined);
+        const area = resolveAreaName(u.area || null, areaId || null);
         const userData: User = {
           uid,
           email: u.email,
           displayName: u.displayName || '',
           role: normalizedRole,
-          area: u.area || null,
+          area: area || null,
+          areaId: areaId || null,
           isActive: true,
           createdAt: Date.now()
         };
@@ -374,12 +536,16 @@ class AuthService {
 
       snap.docs.forEach(docSnap => {
         const data = docSnap.data() as User;
-        const normalizedRole = (data.role || 'applicant').toLowerCase() as 'admin' | 'committee' | 'applicant';
+        const normalizedRole = toStoredRole(data.role);
         const normalizedUid = data.uid || docSnap.id;
+        const areaId = resolveAreaId(data.area || undefined, data.areaId || undefined);
+        const areaName = resolveAreaName(data.area || null, areaId || null);
         const updates: Partial<User> = {};
 
         if (data.role !== normalizedRole) updates.role = normalizedRole;
         if (data.uid !== normalizedUid) updates.uid = normalizedUid;
+        if (areaId && data.areaId !== areaId) updates.areaId = areaId;
+        if (areaName && data.area !== areaName) updates.area = areaName;
 
         if (Object.keys(updates).length > 0) {
           batch.set(doc(db, 'users', docSnap.id), updates, { merge: true });
@@ -428,10 +594,10 @@ class AuthService {
 
         await signOut(secondaryAuth);
 
-        const ref = await this.resolveUserDocRef(user.uid, user.email);
-        if (!ref) throw new Error('User profile not found');
+      const ref = await this.resolveUserDocRef(user.uid, user.email);
+      if (!ref) throw new Error('User profile not found');
 
-        const normalizedRole = (user.role || 'applicant').toLowerCase() as 'admin' | 'committee' | 'applicant';
+        const normalizedRole = toStoredRole(user.role);
         await setDoc(ref, { uid, role: normalizedRole }, { merge: true });
       } catch (error: any) {
         try { await signOut(secondaryAuth); } catch {}
@@ -574,7 +740,7 @@ class AuthService {
   }
 
   mockRegister(e: string, p: string, n: string, role: 'applicant' | 'community' = 'applicant'): Promise<User> {
-    const u: User = { uid: 'u_'+Date.now(), email: e, password: p, displayName: n, role };
+    const u: User = { uid: 'u_'+Date.now(), email: e, password: p, displayName: n, role: toStoredRole(role) };
     this.setLocal('users', [...this.getLocal('users'), u]);
     return Promise.resolve(u);
   }
@@ -582,16 +748,24 @@ class AuthService {
   mockGetApps(area?: string): Promise<Application[]> {
     const apps = this.getLocal<Application>('apps');
     if (apps.length === 0 && !localStorage.getItem('apps_init')) {
-      this.setLocal('apps', DEMO_APPS);
+      const normalized = DEMO_APPS.map(app => mapApplicationFromFirestore(app as Application, app.id));
+      this.setLocal('apps', normalized);
       localStorage.setItem('apps_init', '1');
-      return Promise.resolve(DEMO_APPS);
+      return Promise.resolve(normalized);
     }
-    return Promise.resolve(area && area !== 'All' ? apps.filter(a => a.area === area || a.area === 'Cross-Area') : apps);
+    const mapped = apps.map(app => mapApplicationFromFirestore(app as Application, app.id));
+    if (area && area !== 'All') {
+      const areaId = resolveAreaId(area as Area, null);
+      const crossAreaId = AREA_NAME_TO_ID['Cross-Area'];
+      return Promise.resolve(mapped.filter(a => a.area === area || a.areaId === areaId || a.area === 'Cross-Area' || a.areaId === crossAreaId));
+    }
+    return Promise.resolve(mapped);
   }
 
   mockCreateApp(a: any): Promise<void> {
     const code = a.area?.substring(0,3).toUpperCase() || 'GEN';
-    const na = { ...a, id: 'app_'+Date.now(), createdAt: Date.now(), updatedAt: Date.now(), ref: `PB-${code}-${Math.floor(Math.random()*900)}`, status: 'Submitted-Stage1' as ApplicationStatus };
+    const base = { ...a, id: 'app_'+Date.now(), createdAt: Date.now(), updatedAt: Date.now(), ref: `PB-${code}-${Math.floor(Math.random()*900)}`, status: 'Submitted-Stage1' as ApplicationStatus };
+    const na = mapApplicationFromFirestore(base as Application, base.id);
     this.setLocal('apps', [...this.getLocal('apps'), na]);
     return Promise.resolve();
   }
@@ -599,7 +773,11 @@ class AuthService {
   mockUpdateApp(id: string, up: any): Promise<void> {
     const apps = this.getLocal<Application>('apps');
     const i = apps.findIndex(a => a.id === id);
-    if(i>=0) { apps[i] = { ...apps[i], ...up, updatedAt: Date.now() }; this.setLocal('apps', apps); }
+    if(i>=0) {
+      const updated = mapApplicationFromFirestore({ ...apps[i], ...up, updatedAt: Date.now() } as Application, id);
+      apps[i] = updated;
+      this.setLocal('apps', apps);
+    }
     return Promise.resolve();
   }
 
@@ -610,38 +788,44 @@ class AuthService {
 
   mockSaveVote(vote: Vote): Promise<void> {
     const votes = this.getLocal<Vote>('votes');
+    const normalized = mapVoteToFirestore(vote);
     const i = votes.findIndex(v => v.appId === vote.appId && v.voterId === vote.voterId);
-    if(i>=0) votes[i] = vote; else votes.push(vote);
+    if(i>=0) votes[i] = normalized as Vote; else votes.push(normalized as Vote);
     this.setLocal('votes', votes);
     return Promise.resolve();
   }
 
   mockGetVotes(): Promise<Vote[]> {
-    return Promise.resolve(this.getLocal('votes'));
+    return Promise.resolve(this.getLocal<Vote>('votes').map(vote => mapVoteFromFirestore(vote, vote.id)));
   }
 
   mockSaveScore(s: Score): Promise<void> {
     const scores = this.getLocal<Score>('scores');
     const i = scores.findIndex(x => x.appId === s.appId && x.scorerId === s.scorerId);
-    if(i>=0) scores[i] = s; else scores.push(s);
+    const normalized = mapScoreToFirestore(s);
+    if(i>=0) scores[i] = normalized as Score; else scores.push(normalized as Score);
     this.setLocal('scores', scores);
     return Promise.resolve();
   }
 
   mockGetScores(): Promise<Score[]> {
-    return Promise.resolve(this.getLocal('scores'));
+    return Promise.resolve(this.getLocal<Score>('scores').map(score => mapScoreFromFirestore(score, score.id)));
   }
 
   mockGetUsers(): Promise<User[]> {
     const u = this.getLocal<User>('users');
-    if(u.length === 0) { this.setLocal('users', DEMO_USERS); return Promise.resolve(DEMO_USERS); }
-    return Promise.resolve(u);
+    if(u.length === 0) {
+      const normalized = DEMO_USERS.map(user => mapUserFromFirestore(user as User, user.uid));
+      this.setLocal('users', normalized);
+      return Promise.resolve(normalized);
+    }
+    return Promise.resolve(u.map(user => mapUserFromFirestore(user as User, user.uid)));
   }
 
   mockUpdateUser(u: User): Promise<void> {
     const users = this.getLocal<User>('users');
     const i = users.findIndex(x => x.uid === u.uid);
-    if(i>=0) { users[i] = { ...users[i], ...u }; this.setLocal('users', users); }
+    if(i>=0) { users[i] = { ...users[i], ...u, role: toStoredRole(u.role) }; this.setLocal('users', users); }
     return Promise.resolve();
   }
 
@@ -663,6 +847,7 @@ class AuthService {
       ...u,
       uid,
       password: p, // Only for demo login purposes
+      role: toStoredRole(u.role),
       isActive: true,
       createdAt: Date.now()
     };

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,5 @@
 // utils.ts - Utility Functions for PB Portal
+import { UserRole } from './types';
 
 /**
  * Format a number as GBP currency
@@ -55,3 +56,36 @@ export const ROUTES = {
     SETTINGS: '/portal/settings',
   }
 } as const;
+
+export type StoredRole = 'admin' | 'committee' | 'applicant';
+
+export const toStoredRole = (role: string | undefined | null): StoredRole => {
+  const normalized = (role || '').toString().trim().toLowerCase();
+  if (normalized === 'admin' || normalized === 'committee' || normalized === 'applicant') {
+    return normalized;
+  }
+  if (normalized === 'community' || normalized === 'public') {
+    return 'applicant';
+  }
+  return 'applicant';
+};
+
+export const toUserRole = (role: string | undefined | null): UserRole => {
+  const normalized = (role || '').toString().trim().toUpperCase();
+  switch (normalized) {
+    case UserRole.ADMIN:
+      return UserRole.ADMIN;
+    case UserRole.COMMITTEE:
+      return UserRole.COMMITTEE;
+    case UserRole.APPLICANT:
+      return UserRole.APPLICANT;
+    case UserRole.COMMUNITY:
+      return UserRole.COMMUNITY;
+    default:
+      return UserRole.PUBLIC;
+  }
+};
+
+export const isStoredRole = (role: string | undefined | null, target: StoredRole): boolean => {
+  return toStoredRole(role) === target;
+};


### PR DESCRIPTION
### Motivation

- Introduce canonical PRD identifiers and per-criterion scoring (0–3) while keeping legacy fields for backwards compatibility so persisted records can transition safely to the PRD schema. 
- Provide a mapping layer between legacy field names (e.g. `userId`, `appId`, area names) and PRD fields (e.g. `applicantId`, `applicationId`, `areaId`) when reading/writing Firestore. 
- Normalize stored role values to a small canonical set (`admin|committee|applicant`) while preserving the UI enum for presentation. 
- Ensure scoring UI and services use the canonical per-criterion schema and consistent conversion helpers across routes and layouts.

### Description

- Added PRD/canonical fields and inline mapping notes to types in `types.ts` including `StoredRole`, `areaId`, `applicationId`, `applicantId`, and converted `ScoreBreakdown` to a 0–3 scale while retaining legacy fields for compatibility. 
- Introduced role conversion helpers (`toStoredRole`, `toUserRole`, `isStoredRole`) in `utils.ts` and switched routing/layout checks to use `toUserRole` / `isStoredRole`. 
- Implemented Firestore mapping helpers in `services/firebase.ts` (`mapUserFromFirestore`, `mapApplicationFromFirestore`, `mapVoteFromFirestore`, `mapScoreFromFirestore` and inverse mappers) plus area name ↔ areaId lookup and applied them to reads/writes and mock storage to translate legacy ↔ PRD fields. 
- Updated scoring and voting code paths and UI components (e.g. `components/ScoringModal.tsx`, `views/Secure.tsx`, `pages/secure/ScoringMatrix.tsx`) to emit/consume canonical fields (`applicationId`, `committeeId`, `criterionScores`) and to collect scores on a 0–3 scale with weighted total calculations adjusted accordingly. 

### Testing

- Started the dev server with `npm run dev` and Vite started successfully (development server ready). 
- Exercised basic data flows via the mock/demo handlers updated to use the mapping layer, which run in demo mode (mock functions updated). 
- No unit test suite was added or executed as part of this change. 
- All changes were committed; manual smoke checks were performed by running the app locally via the dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696170e6a9948322b9608db51572a8f2)