### PR TITLE
Add fallback display name in layout

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -139,7 +139,9 @@ export const SecureLayout: React.FC<LayoutProps & { userRole: UserRole }> = ({ c
         <div className="p-4 bg-purple-950 border-t border-purple-800">
            <div className="px-4 py-3 mb-4 bg-purple-900/50 rounded-xl border border-purple-800">
               <p className="text-[10px] font-bold text-purple-400 uppercase leading-none mb-1">Signed in as</p>
-              <p className="text-xs font-bold truncate">{currentUser?.name}</p>
+              <p className="text-xs font-bold truncate">
+                {currentUser?.displayName || currentUser?.username || currentUser?.email || 'Unknown User'}
+              </p>
            </div>
            <button onClick={handleLogout} className="flex items-center space-x-3 text-purple-300 hover:text-white transition w-full px-4 py-2 hover:bg-red-600 rounded-lg text-sm font-bold">
              <LogOut size={16} />


### PR DESCRIPTION
### Motivation
- Avoid rendering a blank signed-in label in the secure sidebar when `currentUser?.name` is missing.
- Prefer showing a human-friendly identifier so users still see who is signed in.

### Description
- Replace the single `currentUser?.name` usage with a fallback chain: `currentUser?.displayName || currentUser?.username || currentUser?.email || 'Unknown User'` in `components/Layout.tsx`.
- Update affects the Signed in as label inside the `SecureLayout` sidebar only.

### Testing
- No automated tests were run for this change.
- No CI test results are available for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696170f89a38832287aac6e3f15a1863)