### PR TITLE
Use `toUserRole` in portal redirect instead of `normalizeRole`

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -110,7 +110,7 @@ const PortalRedirect: React.FC = () => {
     return <Navigate to={ROUTES.PUBLIC.LOGIN} replace />;
   }
 
-  const userRoleNormalized = normalizeRole(userProfile.role);
+  const userRoleNormalized = toUserRole(userProfile.role);
 
   if (userRoleNormalized === UserRole.APPLICANT) {
     return <Navigate to={ROUTES.PORTAL.APPLICANT} replace />;


### PR DESCRIPTION
### Motivation

- Fix a runtime error and ensure consistent role handling by switching to the supported helper for role normalization.
- Ensure applicant vs dashboard routing uses the same `toUserRole` helper as other code paths.
- Remove the last lingering usage of the deprecated/undefined `normalizeRole` helper.

### Description

- Replaced `normalizeRole(userProfile.role)` with `toUserRole(userProfile.role)` in `App.tsx` inside `PortalRedirect`.
- Ensures the portal redirect now routes `UserRole.APPLICANT` to `ROUTES.PORTAL.APPLICANT` and all others to `ROUTES.PORTAL.DASHBOARD` using `toUserRole`.
- No other behavioral changes to route guards or role checks were introduced.

### Testing

- No automated tests were run as part of this change.
- Manual inspection and static analysis of `App.tsx` confirm the usage now references the imported `toUserRole` helper.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618cb708b48322a025d65450a38049)