### PR TITLE
Remove duplicate documentFolders unconditional read rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -182,15 +182,6 @@ service cloud.firestore {
       allow create, update, delete: if isAdmin();
     }
 
-    // Document folders collection
-    match /documentFolders/{folderId} {
-      // Folder lists are readable for navigation
-      allow read: if true;
-
-      // Only admins can manage folders
-      allow create, update, delete: if isAdmin();
-    }
-
     // Audit Logs collection
     match /auditLogs/{logId} {
       // Only admins can read audit logs


### PR DESCRIPTION
### Motivation
- Ensure `documentFolders` read access is governed by `canReadVisibility` and PRD visibility rules.
- Remove a duplicate rule that allowed `allow read: if true` which bypassed visibility gating.

### Description
- Deleted the duplicate `match /documentFolders/{folderId}` block that permitted unconditional reads in `firestore.rules`.
- `documentFolders` reads are now consistently controlled with `canReadVisibility(resource.data.visibility)` while create/update/delete remain admin-only.

### Testing
- No automated tests were run because this is a Firestore rules-only change.
- The change was validated by inspecting the updated `firestore.rules` to confirm the duplicate block was removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618cb93e288322b061f7eb871dda9a)