### PR TITLE
Restrict scoring route to committee role

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -199,11 +199,11 @@ const AppRoutes: React.FC = () => {
         }
       />
 
-      {/* Committee & Admin Only */}
+      {/* Committee Only */}
       <Route
         path={ROUTES.PORTAL.SCORING}
         element={
-          <ProtectedRoute requiredRole={[UserRole.COMMITTEE, UserRole.ADMIN]}>
+          <ProtectedRoute requiredRole={UserRole.COMMITTEE}>
             <ScoringMatrix />
           </ProtectedRoute>
         }


### PR DESCRIPTION
### Motivation
- Prevent admins from entering the scoring UI and ensure only committee members may access the scoring matrix.
- Preserve admin access to scoring status via the admin console rather than the scoring UI itself.

### Description
- Modified `App.tsx` to change the scoring route's `ProtectedRoute` to `requiredRole={UserRole.COMMITTEE}`.
- Updated the route comment from "Committee & Admin Only" to "Committee Only" to reflect the new guard.
- Left the `AdminConsole` route unchanged so admins retain access to admin-only monitoring screens.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618cc56b588322b94a0deca9c9de37)