### PR TITLE
Standardize assignment document IDs

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -25,6 +25,17 @@ The merged portal combines:
 
 ## Architectural Changes
 
+### Assignment ID Migration Plan
+
+Assignments now use a canonical document ID format of `${applicationId}_${committeeId}`. To align existing data with this rule:
+
+1. Export or query all documents from the `assignments` collection.
+2. For each assignment, compute the canonical ID from `applicationId` and `committeeId`.
+3. If the current document ID differs from the canonical ID:
+   - Write the assignment data to a new document with the canonical ID (ensuring the `id` field matches).
+   - Delete the old document ID once the new document is verified.
+4. Re-run any assignment queries in admin tooling to confirm no duplicates remain.
+
 ### 1. Routing System: State-Based → React Router
 
 #### v7 (Original)

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -202,6 +202,10 @@ const mapScoreToFirestore = (score: Score): Partial<Score> => {
   };
 };
 
+const buildAssignmentId = (assignment: Pick<Assignment, 'applicationId' | 'committeeId'>): string => {
+  return `${assignment.applicationId}_${assignment.committeeId}`;
+};
+
 // --- HELPER: CSV Export ---
 export const exportToCSV = (data: any[], filename: string) => {
     if (!data.length) return;
@@ -732,7 +736,8 @@ class AuthService {
 
   async createAssignment(assignment: Assignment): Promise<void> {
       if (USE_DEMO_MODE) return this.mockCreateAssignment(assignment);
-      await setDoc(doc(db, 'assignments', assignment.id), assignment);
+      const id = buildAssignmentId(assignment);
+      await setDoc(doc(db, 'assignments', id), { ...assignment, id });
   }
 
   async updateAssignment(id: string, updates: Partial<Assignment>): Promise<void> {
@@ -983,7 +988,8 @@ class AuthService {
   }
 
   mockCreateAssignment(assignment: Assignment): Promise<void> {
-    this.setLocal('assignments', [...this.getLocal('assignments'), assignment]);
+    const id = buildAssignmentId(assignment);
+    this.setLocal('assignments', [...this.getLocal('assignments'), { ...assignment, id }]);
     return Promise.resolve();
   }
 

--- a/types.ts
+++ b/types.ts
@@ -379,6 +379,7 @@ export interface Round {
  * Committee dashboard task list and allow per‑member progress tracking and due dates.
  */
 export interface Assignment {
+  /** Canonical document ID: `${applicationId}_${committeeId}` */
   id: string;
   applicationId: string;
   committeeId: string;


### PR DESCRIPTION
### Motivation
- Ensure assignment documents use a predictable canonical ID so rules and lookups can rely on a stable key format.
- Prevent arbitrary or duplicate assignment document IDs being written by admin tooling or demo flows.
- Surface the canonical ID format in types to improve developer clarity and tooling correctness.
- Provide a migration plan for existing assignment documents that do not follow the rule.

### Description
- Added a shared helper `buildAssignmentId(assignment)` that returns the canonical ID `${applicationId}_${committeeId}` and used it for document creation in `services/firebase.ts`.
- Updated `createAssignment` (and the demo `mockCreateAssignment`) to write assignment documents using the canonical ID and to ensure the `id` field is set on the stored document.
- Documented the canonical ID format on the `Assignment` interface in `types.ts` as a clarifying comment.
- Added an `Assignment ID Migration Plan` to `MIGRATION_NOTES.md` describing steps to rename or rewrite existing assignment documents to the canonical IDs.

### Testing
- No automated tests were executed as part of this change.
- Manual verification steps are recommended for migration (export, re-write to canonical IDs, verify, delete old docs).
- Existing demo flows were updated to produce consistent IDs in local storage (no external integration tests run).
- Recommend running the project test suite and a migration dry-run before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618cbc5208832284fcf8bd3a1c75c9)