### PR TITLE
Add Area type import for firebase mapping helpers

### DIFF
--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -1,5 +1,5 @@
 // services/firebase.ts
-import { User, Application, Score, PortalSettings, DocumentFolder, DocumentItem, DocumentVisibility, Round, Assignment, Vote, ApplicationStatus, AuditLog } from '../types';
+import { User, Application, Score, PortalSettings, DocumentFolder, DocumentItem, DocumentVisibility, Round, Assignment, Vote, ApplicationStatus, AuditLog, Area } from '../types';
 import { DEMO_USERS, DEMO_APPS, SCORING_CRITERIA } from '../constants';
 import { toStoredRole } from '../utils';
 import { initializeApp, getApp, getApps } from "firebase/app";


### PR DESCRIPTION
### Motivation
- Area mapping helpers in `services/firebase.ts` reference the `Area` type but it was not imported from `../types`, which can cause missing-type errors and implicit-`any` usage.
- Add the explicit `Area` import to align the file's type usage with the declared helpers.

### Description
- Import `Area` from `../types` in `services/firebase.ts` by adding it to the existing import list.
- No other functional changes were made to the file or project.

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript types, which still fails due to existing unrelated TypeScript errors in the repository.
- Confirmed the change did not introduce new type errors or any implicit `any` occurrences beyond the repository's pre-existing issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618cbf83508322a60b773876e06bb1)