### PR TITLE
Add folder slug filtering to DocumentsPage and DocumentsPortal

### DIFF
--- a/pages/secure/DocumentsPortal.tsx
+++ b/pages/secure/DocumentsPortal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { FileText, Eye, FolderOpen } from 'lucide-react';
 import { SecureLayout } from '../../components/Layout';
 import { DataService } from '../../services/firebase';
@@ -8,10 +8,12 @@ import { DocumentFolder, DocumentItem, User, UserRole } from '../../types';
 
 const DocumentsPortal: React.FC = () => {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [documents, setDocuments] = useState<DocumentItem[]>([]);
   const [folders, setFolders] = useState<DocumentFolder[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selectedFolderSlug, setSelectedFolderSlug] = useState(() => searchParams.get('folder') ?? '');
 
   useEffect(() => {
     const user = DataService.getCurrentUser();
@@ -40,6 +42,10 @@ const DocumentsPortal: React.FC = () => {
     void loadDocuments();
   }, [navigate]);
 
+  useEffect(() => {
+    setSelectedFolderSlug(searchParams.get('folder') ?? '');
+  }, [searchParams]);
+
   if (!currentUser) {
     return null;
   }
@@ -50,7 +56,28 @@ const DocumentsPortal: React.FC = () => {
     currentUser.role === 'community' ? UserRole.COMMUNITY :
     UserRole.PUBLIC;
 
-  const folderLookup = useMemo(() => new Map(folders.map(folder => [folder.id, folder.name])), [folders]);
+  const folderById = useMemo(() => new Map(folders.map(folder => [folder.id, folder])), [folders]);
+  const folderBySlug = useMemo(
+    () => new Map(folders.filter(folder => folder.slug).map(folder => [folder.slug, folder])),
+    [folders]
+  );
+  const selectedFolder = selectedFolderSlug ? folderBySlug.get(selectedFolderSlug) : undefined;
+  const filteredDocuments = useMemo(() => {
+    if (!selectedFolderSlug) return documents;
+    if (!selectedFolder) return [];
+    return documents.filter((doc) => doc.folderId === selectedFolder.id);
+  }, [documents, selectedFolder, selectedFolderSlug]);
+
+  const handleFolderFilterChange = (slug: string) => {
+    setSelectedFolderSlug(slug);
+    const nextParams = new URLSearchParams(searchParams);
+    if (slug) {
+      nextParams.set('folder', slug);
+    } else {
+      nextParams.delete('folder');
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
 
   return (
     <SecureLayout userRole={userRole}>
@@ -65,44 +92,74 @@ const DocumentsPortal: React.FC = () => {
         ) : (
           <Card>
             <div className="space-y-4">
-              {documents.length === 0 && (
-                <div className="text-center text-gray-500 py-8">No documents available yet.</div>
-              )}
-              {documents.map(doc => (
-                <div key={doc.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 bg-gray-50 rounded-lg border border-gray-200 hover:border-purple-300 transition">
-                  <div className="flex items-center gap-3">
-                    <div className="w-12 h-12 rounded-lg flex items-center justify-center bg-blue-100">
-                      <FileText className="text-blue-600" />
-                    </div>
-                    <div>
-                      <p className="font-bold text-gray-800">{doc.name}</p>
-                      <div className="flex flex-wrap gap-2 mt-1">
-                        <Badge variant="gray">{doc.visibility}</Badge>
-                        {doc.folderId && doc.folderId !== 'root' && (
-                          <Badge variant="amber">
-                            <FolderOpen size={12} className="mr-1" />
-                            {folderLookup.get(doc.folderId) || 'Folder'}
-                          </Badge>
-                        )}
-                        <span className="text-xs text-gray-500">
-                          {new Date(doc.createdAt).toLocaleDateString()}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  {doc.url && (
-                    <a
-                      href={doc.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg font-bold transition"
+              {folders.length > 0 && (
+                <div className="flex flex-col sm:flex-row sm:items-end gap-4 border-b border-gray-200 pb-4">
+                  <div className="flex-1">
+                    <label className="block text-sm font-bold text-gray-700 mb-2">Filter by folder</label>
+                    <select
+                      className="w-full px-4 py-2 rounded-lg border border-gray-200 focus:border-purple-500 outline-none"
+                      value={selectedFolderSlug}
+                      onChange={(event) => handleFolderFilterChange(event.target.value)}
                     >
-                      <Eye size={16} />
-                      View
-                    </a>
+                      <option value="">All folders</option>
+                      {folders.filter(folder => folder.slug).map(folder => (
+                        <option key={folder.id} value={folder.slug}>
+                          {folder.name} ({folder.slug})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {selectedFolder?.slug && (
+                    <div className="text-xs text-gray-500">
+                      Slug: <span className="font-semibold text-gray-700">{selectedFolder.slug}</span>
+                    </div>
                   )}
                 </div>
-              ))}
+              )}
+              {filteredDocuments.length === 0 && (
+                <div className="text-center text-gray-500 py-8">No documents available yet.</div>
+              )}
+              {filteredDocuments.map(doc => {
+                const folderMeta = doc.folderId ? folderById.get(doc.folderId) : undefined;
+                return (
+                  <div key={doc.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 bg-gray-50 rounded-lg border border-gray-200 hover:border-purple-300 transition">
+                    <div className="flex items-center gap-3">
+                      <div className="w-12 h-12 rounded-lg flex items-center justify-center bg-blue-100">
+                        <FileText className="text-blue-600" />
+                      </div>
+                      <div>
+                        <p className="font-bold text-gray-800">{doc.name}</p>
+                        <div className="flex flex-wrap gap-2 mt-1">
+                          <Badge variant="gray">{doc.visibility}</Badge>
+                          {doc.folderId && doc.folderId !== 'root' && (
+                            <Badge variant="amber" title={folderMeta?.slug ? `Slug: ${folderMeta.slug}` : undefined}>
+                              <FolderOpen size={12} className="mr-1" />
+                              {folderMeta?.name || 'Folder'}
+                              {folderMeta?.slug && (
+                                <span className="ml-1 text-[10px] font-semibold opacity-70">/{folderMeta.slug}</span>
+                              )}
+                            </Badge>
+                          )}
+                          <span className="text-xs text-gray-500">
+                            {new Date(doc.createdAt).toLocaleDateString()}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    {doc.url && (
+                      <a
+                        href={doc.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg font-bold transition"
+                      >
+                        <Eye size={16} />
+                        View
+                      </a>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </Card>
         )}


### PR DESCRIPTION
### Motivation
- Allow administrators to expose and use human-friendly folder slugs for navigation and URL-based filtering (e.g. `?folder=slug`).
- Surface folder slug metadata in the UI so slugs created by admins are visible and useful to users.
- Provide an optional folder selector + query-param sync without changing existing default listing behavior.

### Description
- Added `useSearchParams` and a `selectedFolderSlug` state to `pages/public/DocumentsPage.tsx` and `pages/secure/DocumentsPortal.tsx` to read and write the `folder` query parameter.
- Built `folderById` / `folderBySlug` lookup maps and apply folder-based filtering when a `folder` slug is present while keeping `PUBLIC_DOCS` fallback intact for the public page.
- Added folder selector controls (showing only folders that have a `slug`) and surfaced slugs in selector options and folder badges/tooltips for context.
- Kept original UI and seed-document behavior unchanged; downloads/views remain available and filtering is opt-in via the query param or selector.

### Testing
- Launched the dev server with `npm run dev` which started `vite` successfully and served the app at `http://localhost:4173/`.
- Captured a browser screenshot of the public resources page using a Playwright script which completed and produced `artifacts/documents-page.png`.
- Verified the new UI renders and the selector/slug badges appear in the running dev build (manual automated screenshot verification).
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961921262a48322a2beb9dfeba6f08c)