### PR TITLE
Support areaId matching in committee access rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -27,8 +27,11 @@ service cloud.firestore {
       return isAuthenticated() && request.auth.uid == userId;
     }
 
-    function committeeAreaMatches(area) {
-      return getUserData().area == area || area == 'Cross-Area';
+    function committeeAreaMatches(area, areaId) {
+      return (area != null && getUserData().area == area) ||
+             (areaId != null && getUserData().areaId == areaId) ||
+             area == 'Cross-Area' ||
+             areaId == 'cross-area';
     }
 
     function getApplicantId(data) {
@@ -91,7 +94,7 @@ service cloud.firestore {
 
       // Committee members can read assigned applications in their area
       allow read: if isCommittee() &&
-                     committeeAreaMatches(resource.data.area) &&
+                     committeeAreaMatches(resource.data.area, resource.data.areaId) &&
                      hasAssignment(appId);
 
       // Admins can do everything with applications
@@ -106,7 +109,10 @@ service cloud.firestore {
       // Committee members can create votes for applications in their area
       allow create: if isCommittee() &&
                        getVoterId(request.resource.data) == request.auth.uid &&
-                       committeeAreaMatches(get(/databases/$(database)/documents/applications/$(request.resource.data.appId)).data.area);
+                       committeeAreaMatches(
+                         get(/databases/$(database)/documents/applications/$(request.resource.data.appId)).data.area,
+                         get(/databases/$(database)/documents/applications/$(request.resource.data.appId)).data.areaId
+                       );
 
       // Committee members can update their own votes
       allow update: if isCommittee() &&
@@ -124,7 +130,10 @@ service cloud.firestore {
       // Committee members can create scores for applications in their area
       allow create: if isCommittee() &&
                        getScorerId(request.resource.data) == request.auth.uid &&
-                       committeeAreaMatches(get(/databases/$(database)/documents/applications/$(request.resource.data.appId)).data.area);
+                       committeeAreaMatches(
+                         get(/databases/$(database)/documents/applications/$(request.resource.data.appId)).data.area,
+                         get(/databases/$(database)/documents/applications/$(request.resource.data.appId)).data.areaId
+                       );
 
       // Committee members can update their own scores (if not final)
       allow update: if isCommittee() &&


### PR DESCRIPTION
### Motivation
- Ensure committee access remains stable during migration from legacy `area` names to canonical `areaId` slugs.
- Preserve the assignment-driven access model by keeping the `hasAssignment` gating intact.
- Allow committee checks to recognize cross-area applications via both legacy and canonical fields.

### Description
- Update `committeeAreaMatches` in `firestore.rules` to accept an additional `areaId` parameter and check both `area` and `areaId` values.
- Treat `Cross-Area` and the canonical `cross-area` slug as equivalent allowed values in the matcher.
- Pass `resource.data.areaId` (and application `areaId` when reading app docs) into calls from `applications`, `votes`, and `scores` rules.
- No changes were made to the `hasAssignment` logic or assignment-related checks.

### Testing
- No automated tests were executed for this rules-only change.
- The change was lint-free and committed to the branch (rules file updated and committed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69619216ca388322984c67de02488d3d)