### PR TITLE
Prevent deletion of non-empty document folders

### DIFF
--- a/PRD.txt
+++ b/PRD.txt
@@ -262,7 +262,7 @@ Threshold evaluation:‎
 •	Admin can upload documents, set title, folder, visibility (public/committee/admin), and ‎delete documents.‎
 •	Documents must persist: metadata in Firestore, file in Storage.‎
 •	Committee sees only committee/public documents; applicant sees only public documents.‎
-•	Folder delete behaviour: if folder contains documents, either (a) prevent deletion and ‎prompt to move docs, or (b) cascade by moving docs to an 'Unfiled' folder. Choose one; ‎default is prevent deletion.‎
+•	Folder delete behaviour (chosen): prevent deletion when a folder contains documents. Show ‎UI copy: “This folder contains documents. Move them to another folder before deleting.”‎
 ‎13. Formatting, UI copy, and branding (fixes)‎
 ‎13.1 Currency formatting (GBP only)‎
 •	All monetary values must render in GBP (£) using Intl.NumberFormat('en-GB', { style: ‎‎'currency', currency: 'GBP' }).‎

--- a/pages/secure/AdminConsole.tsx
+++ b/pages/secure/AdminConsole.tsx
@@ -1627,10 +1627,11 @@ const AdminConsole: React.FC = () => {
 
     const handleDeleteFolder = async (folder: DocumentFolder) => {
       const docsInFolder = documents.filter(doc => doc.folderId === folder.id);
-      const message = docsInFolder.length > 0
-        ? `This folder contains ${docsInFolder.length} document(s). Delete "${folder.name}" anyway?`
-        : `Are you sure you want to delete "${folder.name}"?`;
-      if (!confirm(message)) return;
+      if (docsInFolder.length > 0) {
+        alert(`"${folder.name}" contains ${docsInFolder.length} document(s). Move documents to another folder before deleting.`);
+        return;
+      }
+      if (!confirm(`Are you sure you want to delete "${folder.name}"?`)) return;
       try {
         await DataService.deleteDocumentFolder(folder.id);
         await DataService.logAction({


### PR DESCRIPTION
### Motivation
- Enforce the PRD-approved folder-delete behaviour to avoid accidental loss or orphaned documents by preventing deletion of folders that still contain documents.
- Provide clear admin guidance in the UI when deletion is blocked so admins know to move documents first.

### Description
- Update `handleDeleteFolder` in `pages/secure/AdminConsole.tsx` to check for documents in the folder and `alert` the admin with the message and abort deletion when any documents exist, preserving the existing confirmation when the folder is empty.
- Leave auditing and the actual `DataService.deleteDocumentFolder` call intact for the empty-folder flow, and refresh data via `loadAllData()` after deletion.
- Update `PRD.txt` (section “Documents and folders”) to explicitly state the chosen behaviour and include the exact UI copy: “This folder contains documents. Move them to another folder before deleting.”

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c2ec6e6c8322bcfeccebaeda7d12)