### PR TITLE
PRD v5: Align documents schema, visibility and Storage deletion behaviour

### DIFF
--- a/PRD.txt
+++ b/PRD.txt
@@ -1,7 +1,7 @@
 Communities’ Choice Participatory ‎Budgeting Portal 
 Final Product Requirements ‎Document (PRD)‎
-Version: FINAL (v4) 
-Date: 2026-01-01 
+Version: FINAL (v5) 
+Date: 2026-02-14 
 Owner: Torfaen Voluntary Alliance (TVA) – Communities’ Choice Team
 
 Document status	Final / implementation-ready
@@ -158,15 +158,20 @@ timestamp	timestamp	Yes	When saved
 ‎6.7 documents/{docId} and documentFolders/{folderId}‎
 Folders must be real (not UI-only). Implement either documentFolders collection OR admin-‎editable folder list in portal settings. Canonical approach below uses documentFolders.‎
 Entity	Field	Type	Required	Description
+documentFolders	id	string	Yes	Document ID (matches document ID)
 documentFolders	name	string	Yes	Folder display ‎name
 documentFolders	slug	string	Yes	Stable key for ‎routing/filtering
+documentFolders	visibility	‎'public'|'committee'|'admin‎‎'‎	Yes	Who can read
 documentFolders	createdAt	timestamp	Yes	Created ‎timestamp
-documents	title	string	Yes	Document title
-documents	folderId	string	Yes	Folder reference
-documents	visibility	‎'public'|'committee'|'admin‎‎'‎	Yes	Who can read
+documentFolders	createdBy	string	Yes	Admin UID
+documents	id	string	Yes	Document ID (matches document ID)
+documents	name	string	Yes	Document title
+documents	url	string	No	Public download URL (if stored)
 documents	filePath	string	Yes	Storage path
+documents	folderId	string	Yes	Folder reference (or 'root'/null for unfiled)
+documents	visibility	‎'public'|'committee'|'admin‎‎'‎	Yes	Who can read
 documents	uploadedBy	string	Yes	Admin UID
-documents	uploadedAt	timestamp	Yes	Upload ‎timestamp
+documents	createdAt	timestamp	Yes	Created ‎timestamp
 
 ‎6.8 portalSettings/{id='global'}‎
 Field	Type	Required	Description
@@ -188,7 +193,7 @@ timestamp	timestamp	Yes	When logged
 ‎7. Public site requirements‎
 •	Public header includes: logo (public logo), navigation (Home, Priorities, Voting Zone, ‎Resources), CTA button ‘Secure Portal’.‎
 •	Public site content uses UK English and Communities’ Choice branding.‎
-•	Resources page must support a curated list of public documents/links; if documents are ‎served via the document module, only 'public' visibility documents are shown.‎
+•	Resources page must support a curated list of public documents/links; if documents are ‎served via the document module, only 'public' visibility documents are shown. If no public ‎documents exist yet, the page uses the seeded public documents list as a temporary fallback ‎(flag for removal once the live public documents collection is populated).‎
 •	Voting Zone: either (a) placeholder explaining voting dates; or (b) live voting (if already ‎implemented). Do not remove existing capability.‎
 ‎8. Authentication, sessions, and profile‎
 ‎8.1 Authentication‎
@@ -261,6 +266,7 @@ Threshold evaluation:‎
 •	Admin can create/rename/delete document folders (documentFolders).‎
 •	Admin can upload documents, set title, folder, visibility (public/committee/admin), and ‎delete documents.‎
 •	Documents must persist: metadata in Firestore, file in Storage.‎
+•	Visibility filters are applied per view: public resources = visibility 'public' only; committee ‎views = visibility in ['public','committee']; admin views = all documents or filtered by ‎selected visibility.‎
 •	Committee sees only committee/public documents; applicant sees only public documents.‎
 •	Folder delete behaviour: if folder contains documents, either (a) prevent deletion and ‎prompt to move docs, or (b) cascade by moving docs to an 'Unfiled' folder. Choose one; ‎default is prevent deletion.‎
 ‎13. Formatting, UI copy, and branding (fixes)‎
@@ -309,7 +315,7 @@ Admin console includes modules and behaviours below. All changes must write audi
 •	Avoid NaN: when no scores, average shows 0 and 'No scores yet'.‎
 ‎14.7 Documents centre‎
 •	Upload document, set folder, set visibility.‎
-•	Delete document removes metadata + file from Storage.‎
+•	Delete document removes metadata + file from Storage. If a filePath is not supplied to the ‎delete action, resolve it from the documents/{docId} record first; if Storage deletion fails, log ‎a warning and still delete Firestore metadata.‎
 •	Folder manager present (create/rename/delete).‎
 ‎14.8 Portal settings‎
 •	Admin can set default scoring threshold and confirm currency=GBP.‎


### PR DESCRIPTION
### Motivation

- Bring the PRD into alignment with the current code by updating the documents/folders data model to match `types.ts` and `services/firebase.ts` behaviour.  
- Make the expected Storage deletion behaviour and visibility filtering explicit so implementers know how `deleteDocument` and view filters should operate.  
- Keep the PRD accurate for implementers and preserve UK English and the existing public documents fallback policy (marked as a temporary fallback).  

### Description

- Bumped `PRD.txt` to Version: FINAL (v5) and updated the date to `2026-02-14`.  
- Reworked Section 6.7 to align the documents and folders schema with the code, introducing canonical fields such as `DocumentItem`/`documents` fields (`id`, `name` (title), `url`, `filePath`, `folderId`, `visibility`, `uploadedBy`, `createdAt`) and `DocumentFolder`/`documentFolders` fields (including `id`, `name`, `slug`, `visibility`, `createdAt`, `createdBy`).  
- Documented Storage deletion behaviour used by `deleteDocument` (resolve `filePath` from `documents/{docId}` if not supplied, attempt `deleteObject`, warn on failure and still remove Firestore metadata) and clarified visibility filter rules for public/committee/admin views.  
- Explicitly recorded the seeded public documents fallback for the public Resources page as a temporary fallback until live public documents exist and reiterated UK English usage.  

### Testing

- No automated tests were run because this is a documentation-only change; no code behaviour was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c2ee25b88322a4f057fc4640db43)