### PR TITLE
Public Resources: remove seed fallback, add admin-aware empty state and PRD v5 update

### DIFF
--- a/PRD.txt
+++ b/PRD.txt
@@ -1,6 +1,6 @@
 Communities’ Choice Participatory ‎Budgeting Portal 
 Final Product Requirements ‎Document (PRD)‎
-Version: FINAL (v4) 
+Version: FINAL (v5) 
 Date: 2026-01-01 
 Owner: Torfaen Voluntary Alliance (TVA) – Communities’ Choice Team
 
@@ -189,6 +189,7 @@ timestamp	timestamp	Yes	When logged
 •	Public header includes: logo (public logo), navigation (Home, Priorities, Voting Zone, ‎Resources), CTA button ‘Secure Portal’.‎
 •	Public site content uses UK English and Communities’ Choice branding.‎
 •	Resources page must support a curated list of public documents/links; if documents are ‎served via the document module, only 'public' visibility documents are shown.‎
+•	Seed content (PUBLIC_DOCS) is a temporary placeholder for design/testing only. In production, all roles see Firestore-backed documents. If no public documents exist, the public Resources page shows an explicit empty state. Admins see guidance with a CTA to upload public documents in the secure Documents area; applicants/committee/public visitors see a “no documents yet” message. This keeps the public UX clear while prompting admins to populate content.‎
 •	Voting Zone: either (a) placeholder explaining voting dates; or (b) live voting (if already ‎implemented). Do not remove existing capability.‎
 ‎8. Authentication, sessions, and profile‎
 ‎8.1 Authentication‎

--- a/constants.ts
+++ b/constants.ts
@@ -225,7 +225,7 @@ export const ORG_TYPES = [
 // DOCUMENT RESOURCES
 // ============================================================================
 
-// Public Documents - Available to all applicants
+// Public Documents - Temporary seed list for design/dev previews
 export const PUBLIC_DOCS = [
   {
     title: 'PB 1.1 - EOI Form (Part 1)',


### PR DESCRIPTION
### Motivation
- Prevent silent fallback to in-repo seed content and make the public Resources page rely on Firestore documents by default.  
- Make the UI explicit when no public documents exist so applicants/public users see a clear message and admins get actionable guidance.  
- Document the intended behaviour and role differences in the project PRD to avoid ambiguity about `PUBLIC_DOCS`.  

### Description
- `pages/public/DocumentsPage.tsx`: removed `PUBLIC_DOCS` fallback, fetches Firestore via `DataService.getDocuments` / `DataService.getDocumentFolders`, shows folder filter only when there are Firestore documents, and renders a role-aware empty state (admins see CTA linking to `ROUTES.PORTAL.DOCUMENTS`).  
- `constants.ts`: updated `PUBLIC_DOCS` comment to mark it as a temporary seed list for design/dev previews.  
- `PRD.txt`: bumped to `v5` and added explicit guidance describing fallback behaviour and which roles see Firestore content vs seed content, and that admins should be prompted to upload public docs.  

### Testing
- Started the dev server with `npm run dev` and the Vite server reported ready on the expected port (success).  
- Automated Playwright script navigated to `/resources` and produced a screenshot of the empty-state UI (`artifacts/public-documents-empty.png`) confirming the new messaging (success).  
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c2effcd483229528547c0168ae17)