### PR TITLE
Add public voting capture, eligibility gating, and validation

### DIFF
--- a/pages/public/PostcodeCheckPage.tsx
+++ b/pages/public/PostcodeCheckPage.tsx
@@ -12,6 +12,7 @@ const PostcodeCheckPage: React.FC = () => {
   const [result, setResult] = useState<{ eligible: boolean; area?: string; formUrl?: string } | null>(null);
   const [isChecking, setIsChecking] = useState(false);
   const [settings, setSettings] = useState<PortalSettings | null>(null);
+  const eligibilityStorageKey = 'pb_public_vote_eligibility';
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -38,6 +39,10 @@ const PostcodeCheckPage: React.FC = () => {
 
       for (const [key, areaData] of Object.entries(AREA_DATA)) {
         if (areaData.postcodes.includes(normalized)) {
+          localStorage.setItem(eligibilityStorageKey, JSON.stringify({
+            area: areaData.name,
+            checkedAt: Date.now()
+          }));
           setResult({
             eligible: true,
             area: areaData.name,

--- a/pages/public/PublicVotingPage.tsx
+++ b/pages/public/PublicVotingPage.tsx
@@ -1,27 +1,51 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { PublicLayout } from '../../components/Layout';
 import { Vote as VoteIcon, Users, MapPin, Coins, CheckCircle2, Clock, ArrowRight, Calendar, AlertCircle } from 'lucide-react';
 import { DataService } from '../../services/firebase';
-import { Application, PortalSettings } from '../../types';
+import { Application, PortalSettings, PublicVote } from '../../types';
 import { ROUTES } from '../../utils';
 import { getAreaColor } from '../../constants';
 
 const PublicVotingPage: React.FC = () => {
+  const navigate = useNavigate();
   const [applications, setApplications] = useState<Application[]>([]);
   const [settings, setSettings] = useState<PortalSettings | null>(null);
+  const [publicVotes, setPublicVotes] = useState<PublicVote[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedArea, setSelectedArea] = useState<string>('All');
+  const [error, setError] = useState<string | null>(null);
+  const eligibilityStorageKey = 'pb_public_vote_eligibility';
+  const voterIdStorageKey = 'pb_public_voter_id';
 
   useEffect(() => {
     loadData();
   }, []);
 
+  const getOrCreateVoterId = () => {
+    const existing = localStorage.getItem(voterIdStorageKey);
+    if (existing) return existing;
+    const newId = (globalThis.crypto?.randomUUID?.() ?? `pv_${Date.now()}_${Math.random().toString(16).slice(2)}`);
+    localStorage.setItem(voterIdStorageKey, newId);
+    return newId;
+  };
+
+  const getEligibility = () => {
+    const stored = localStorage.getItem(eligibilityStorageKey);
+    if (!stored) return null;
+    try {
+      return JSON.parse(stored) as { area: string; checkedAt: number };
+    } catch (error) {
+      return null;
+    }
+  };
+
   const loadData = async () => {
     try {
-      const [appsData, settingsData] = await Promise.all([
+      const [appsData, settingsData, publicVotesData] = await Promise.all([
         DataService.getApplications(),
-        DataService.getPortalSettings()
+        DataService.getPortalSettings(),
+        DataService.getPublicVotes()
       ]);
 
       // Filter for funded applications with public vote pack complete
@@ -31,8 +55,10 @@ const PublicVotingPage: React.FC = () => {
 
       setApplications(votableApps);
       setSettings(settingsData);
+      setPublicVotes(publicVotesData);
     } catch (error) {
       console.error('Error loading public voting data:', error);
+      setError('Unable to load public voting data. Please try again later.');
     } finally {
       setLoading(false);
     }
@@ -49,6 +75,39 @@ const PublicVotingPage: React.FC = () => {
     (!votingEndDate || now <= votingEndDate)
   );
   const votingOpen = (settings?.votingOpen === true) && isWithinDateRange;
+
+  const eligibility = getEligibility();
+  const voterId = getOrCreateVoterId();
+  const myVotes = publicVotes.filter(vote => vote.voterId === voterId);
+
+  const handleVote = async (app: Application) => {
+    if (!votingOpen) {
+      alert('Public voting is not currently open.');
+      return;
+    }
+
+    if (!eligibility) {
+      navigate(ROUTES.PUBLIC.VOTING_ZONE);
+      return;
+    }
+
+    try {
+      const vote: PublicVote = {
+        id: `${app.id}_${voterId}`,
+        applicationId: app.id,
+        voterId,
+        area: eligibility.area,
+        createdAt: new Date().toISOString()
+      };
+      await DataService.savePublicVote(vote);
+      const updatedVotes = await DataService.getPublicVotes();
+      setPublicVotes(updatedVotes);
+      alert('Thank you! Your vote has been recorded.');
+    } catch (error) {
+      console.error('Failed to submit public vote:', error);
+      alert('Unable to record your vote right now. Please try again.');
+    }
+  };
 
   // Format dates for display
   const formatDate = (timestamp: number | undefined) => {
@@ -73,6 +132,19 @@ const PublicVotingPage: React.FC = () => {
       <PublicLayout>
         <div className="min-h-[60vh] flex items-center justify-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+        </div>
+      </PublicLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <PublicLayout>
+        <div className="max-w-3xl mx-auto text-center py-20">
+          <div className="bg-red-50 border border-red-200 rounded-2xl p-6">
+            <AlertCircle size={32} className="text-red-500 mx-auto mb-3" />
+            <p className="text-red-700 font-semibold">{error}</p>
+          </div>
         </div>
       </PublicLayout>
     );
@@ -156,6 +228,29 @@ const PublicVotingPage: React.FC = () => {
           >
             <ArrowRight size={20} />
             Back to Home
+          </Link>
+        </div>
+      </PublicLayout>
+    );
+  }
+
+  if (!eligibility) {
+    return (
+      <PublicLayout>
+        <div className="max-w-4xl mx-auto text-center py-20">
+          <div className="w-20 h-20 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-6">
+            <AlertCircle size={40} className="text-purple-600" />
+          </div>
+          <h1 className="text-4xl font-bold text-purple-900 mb-4 font-display">Check Your Eligibility First</h1>
+          <p className="text-lg text-purple-700 mb-8">
+            Please check your postcode to confirm eligibility before voting on projects.
+          </p>
+          <Link
+            to={ROUTES.PUBLIC.VOTING_ZONE}
+            className="inline-flex items-center gap-2 bg-purple-600 hover:bg-purple-700 text-white px-8 py-4 rounded-xl font-bold transition-all"
+          >
+            <MapPin size={20} />
+            Check My Postcode
           </Link>
         </div>
       </PublicLayout>
@@ -293,10 +388,20 @@ const PublicVotingPage: React.FC = () => {
                   </div>
 
                   {/* Vote Button */}
-                  <button className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 rounded-xl font-bold transition-all flex items-center justify-center gap-2">
-                    <VoteIcon size={20} />
-                    Vote for This Project
-                  </button>
+                  {myVotes.some(vote => vote.applicationId === app.id) ? (
+                    <div className="w-full bg-green-100 text-green-700 py-3 rounded-xl font-bold flex items-center justify-center gap-2">
+                      <CheckCircle2 size={20} />
+                      Vote Recorded
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => handleVote(app)}
+                      className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 rounded-xl font-bold transition-all flex items-center justify-center gap-2"
+                    >
+                      <VoteIcon size={20} />
+                      Vote for This Project
+                    </button>
+                  )}
                 </div>
               </div>
             ))}

--- a/pages/secure/Dashboard.tsx
+++ b/pages/secure/Dashboard.tsx
@@ -396,6 +396,8 @@ const ApplicantDashboard: React.FC<ApplicantDashboardProps> = ({ applications, c
   const [publicVoteBlurb, setPublicVoteBlurb] = useState('');
   const [publicVoteImageFile, setPublicVoteImageFile] = useState<File | null>(null);
   const [uploadingImage, setUploadingImage] = useState(false);
+  const publicVoteBlurbWordCount = publicVoteBlurb.split(/\s+/).filter(Boolean).length;
+  const isPublicBlurbValid = publicVoteBlurbWordCount <= 200;
   const draftApps = applications.filter(app => app.status === 'Draft');
   const submittedApps = applications.filter(app => app.status.includes('Submitted'));
   const fundedApps = applications.filter(app => app.status === 'Funded');
@@ -410,6 +412,11 @@ const ApplicantDashboard: React.FC<ApplicantDashboardProps> = ({ applications, c
   const handleSubmitPublicPack = async () => {
     if (!publicPackApp || !publicVoteBlurb || !publicVoteImageFile) {
       alert('Please provide both an image and a blurb');
+      return;
+    }
+
+    if (!isPublicBlurbValid) {
+      alert('Please keep your public vote description to 200 words or less.');
       return;
     }
 
@@ -574,15 +581,18 @@ const ApplicantDashboard: React.FC<ApplicantDashboardProps> = ({ applications, c
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent"
                 />
                 <p className="text-sm text-gray-500 mt-1">
-                  {publicVoteBlurb.split(/\s+/).filter(Boolean).length} / 200 words
+                  {publicVoteBlurbWordCount} / 200 words
                 </p>
+                {!isPublicBlurbValid && (
+                  <p className="text-sm text-red-600 mt-1">Please reduce your description to 200 words or fewer.</p>
+                )}
               </div>
 
               {/* Submit Button */}
               <div className="flex gap-4">
                 <button
                   onClick={handleSubmitPublicPack}
-                  disabled={submittingPublicPack || !publicVoteBlurb || !publicVoteImageFile}
+                  disabled={submittingPublicPack || !publicVoteBlurb || !publicVoteImageFile || !isPublicBlurbValid}
                   className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-gray-300 text-white px-6 py-3 rounded-xl font-bold transition"
                 >
                   {uploadingImage ? 'Uploading Image...' : submittingPublicPack ? 'Submitting...' : 'Submit Public Vote Pack'}

--- a/pages/secure/ScoringMatrix.tsx
+++ b/pages/secure/ScoringMatrix.tsx
@@ -47,6 +47,10 @@ const ScoringMatrix: React.FC = () => {
       return { allowed: false, reason: 'Scoring is currently closed for this funding round.' };
     }
 
+    if (portalSettings?.stage2ScoringOpen === false) {
+      return { allowed: false, reason: 'Scoring is currently closed by the portal administrator.' };
+    }
+
     return { allowed: true };
   };
 

--- a/types.ts
+++ b/types.ts
@@ -135,6 +135,16 @@ export interface Vote {
   createdAt: string;
 }
 
+// --- PUBLIC VOTING ---
+
+export interface PublicVote {
+  id: string;
+  applicationId: string;
+  voterId: string;
+  area?: Area;
+  createdAt: string;
+}
+
 // --- SCORING (Stage 2) ---
 
 export interface ScoreBreakdown {


### PR DESCRIPTION
### Motivation

- Add an end-to-end public voting flow so community members can cast public votes on funded projects while ensuring only eligible residents participate.  
- Persist public votes (with demo-mode support) and surface live public vote totals for administrators.  
- Enforce applicant-side constraints for public vote packs and respect portal-level scoring flags for committee scoring.  

### Description

- Introduced a `PublicVote` type and added `savePublicVote` / `getPublicVotes` implementations plus demo-mode mocks in `services/firebase.ts`.  
- Gate public voting behind the postcode eligibility check by storing eligibility in `localStorage` from `pages/public/PostcodeCheckPage.tsx` and requiring it on `pages/public/PublicVotingPage.tsx`, including a per-user `voterId` and client-side duplicate vote display.  
- Show live public vote totals in the admin console by loading `publicVotes` in `pages/secure/AdminConsole.tsx` and rendering per-project counts.  
- Enforce a 200-word limit for applicant public vote blurbs in `pages/secure/Dashboard.tsx` and respect `portalSettings.stage2ScoringOpen` in `pages/secure/ScoringMatrix.tsx` when allowing scorers to submit scores.  

### Testing

- Started the dev server with `npm run dev` and Vite reported ready (local server started); this succeeded.  
- Attempted an automated Playwright page capture against the running dev server but the browser process crashed in this environment, so the end-to-end headless check failed.  
- No unit or integration test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e12a732c8322aef9fa8a08d9c5c8)